### PR TITLE
allow eval() for defined installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 installations.txt
+alloweval.txt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This script
 - makes sure, missing indices and columns are added
 - updates apps, if available
 - updates the nextcloud instance
+- allow eval() for defined installations
 - supports multiple instances inside one hoster account
 
 Make sure, that this script runs on your installation. It works for me. Use it on your own risk!
@@ -23,11 +24,13 @@ To update call the update.sh file
 * cd into the new created directory (`cd helpers/all-inkl-nc-updater` in this example)
 * call `chmod 744 ./all-inkl-nc-updater/update.sh`
 * call `touch installations.txt`
+* call `touch alloweval.txt`
 * open installations.txt in your editor and enter your installations relative to your accounts root
   * i.e. if your install directory (nextcloud root) is /www/htdocs/w000000/domain.com/nextcloud
   * then add "domain.com/nextcloud" to the `installations.txt`
   * for multiple installations add more lines with the correct path to the installation (see `installations.txt.sample`)
-
+* open alloweval.txt and add your installations, where eval() should be allowed
+  * the schema is identical to installations.txt
 ## get updates (via git)
 * log in to your server via ssh
 * cd into the directory created above (`cd helpers` in this example)

--- a/alloweval.txt.sample
+++ b/alloweval.txt.sample
@@ -1,0 +1,2 @@
+foo.com/nextcloud
+bar.com/nextcloud/server

--- a/update.sh
+++ b/update.sh
@@ -105,6 +105,14 @@ function update_nc_version()
 	php -d memory_limit=$php_memory_limit $nc_base/updater/updater.phar -n
 }
 
+function allow_eval_patch()
+{
+	patch_file=$nc_base/lib/public/AppFramework/Http/ContentSecurityPolicy.php
+	logger "- patching $patch_file"
+	logger "- replace \e[1m\e[95mprotected \e[91m\$evalScriptAllowed \e[95m= \e[32mfalse \e[0mwith \e[1m\e[95mprotected \e[91m\$evalScriptAllowed \e[95m= \e[32mtrue"
+	sed -i 's/protected $evalScriptAllowed = false/protected $evalScriptAllowed = true/g' $patch_file
+}
+
 # init check variables
 update_available=0
 
@@ -119,6 +127,10 @@ account_base="/www/htdocs/${USER//ssh-}"
 # i.e. if your install directory (nextcloud root) is /www/htdocs/w000000/domain.com/nextcloud
 # then add "domain.com/nextcloud" to the installations.txt
 installations="$script_dir/installations.txt"
+
+# same as installations, but for patching for allowing JS eval
+# use this for dev systems, where you have to allow eval (i.e. for dev tools)
+alloweval="$script_dir/alloweval.txt"
 
 # define the php_memory_limit
 php_memory_limit="512M"
@@ -158,3 +170,17 @@ while read install_dir; do
 		fi
 	fi
 done <$installations
+
+while read install_dir; do
+	nc_base=$account_base/$install_dir
+
+	logger " "
+	logger "=================================="
+	logger "- nextcloud installation: \e[96m$install_dir"
+	logger "=================================="
+	logger "- account base: \e[32m$account_base"
+	logger "- nextcloud base dir: \e[32m$nc_base"
+	logger "=================================="
+
+	allow_eval_patch
+done <$alloweval


### PR DESCRIPTION
Adding a function to allow patching of `/lib/public/AppFramework/Http/ContentSecurityPolicy.php`
This changes `protected $evalScriptAllowed = false;` to `protected $evalScriptAllowed = true;` 
